### PR TITLE
Add Voidlinux installation script in install.sh check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,9 @@ LOGS_INSTALL_LOG_FILE_PATH="$LOGS_DIR_PATH/$LOGS_INSTALL_LOG_FILE_NAME"
     elif [[ $(sudo zypper help 2>/dev/null) ]]; then
         PACKAGE_MANAGER="zypper"
         sudo zypper --non-interactive install ibus libevdev2 curl xinput i2c-tools python3-devel python3-virtualenv libxml2 libxkbcommon-devel gcc
+    elif [[ $(sudo xbps-install --help 2>/dev/null) ]]; then
+        PACKAGE_MANAGER="xbps-install"
+        sudo xbps-install -Suy ibus-devel libevdev-devel curl xinput i2c-tools python3-devel python3-virtualenv libxml2 libxkbcommon-devel gcc 
     else
         echo "Not detected package manager. Driver may not work properly because required packages have not been installed. Please create an issue (https://github.com/asus-linux-drivers/asus-numberpad-driver/issues)."
     fi


### PR DESCRIPTION
Voidlinux using runit system you must add start script somewhere after start your WM
see [FAQ: How to start NumberPad without systemd service?](https://github.com/asus-linux-drivers/asus-numberpad-driver?tab=readme-ov-file#faq)