### PR TITLE
Fix internal modifier keys

### DIFF
--- a/numberpad.py
+++ b/numberpad.py
@@ -1671,6 +1671,7 @@ def pressed_numpad_key():
             grab_current_slot()
 
           udev.send_events(events)
+          sleep(0.005)
         except OSError as e:
           log.warning("Cannot send press event, %s", e)
 


### PR DESCRIPTION
Fixes #210

I really don't get why this is needed. I thought the whole idea behind `EV_SYN` was to avoid physical delays? Is this related to Wayland or something?