### PR TITLE
[#234] fix: Installation on X11 on NixOS, add: ignoreWaylandDisplayEnv config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,10 @@ or for NixOS you can use flakes for the installation of this driver.
 
 > [!IMPORTANT]
 > In case the layout isn't provided, the default numpad layout is "up5401ea" make sure to change it to your layout in the configuration.
+
 > The default value for runtimeDir is `/run/usr/1000/`, for waylandDisplay is `wayland-0` and wayland is `true`.
+
+> Enabling `ignoreWaylandDisplayEnv` removes the explicit declaration of `WAYLAND_DISPLAY` in the service, allowing it to function correctly when switching between desktop environments or window managers that may have different `WAYLAND_DISPLAY` environment variables.
 
 <details>
 <summary>The driver installation (NixOS)</summary>
@@ -164,7 +167,9 @@ This repo contains a Flake that exposes a NixOS Module that manages and offers o
     }
 }
 ```
+
 Then you can enable the program in your `configuration.nix` file:
+
 ```nix
 # configuration.nix
 
@@ -177,6 +182,7 @@ Then you can enable the program in your `configuration.nix` file:
     wayland = true;
     runtimeDir = "/run/user/1000/";
     waylandDisplay = "wayland-0";
+    ignoreWaylandDisplayEnv = "false";
     config = {
       # e.g. "activation_time" = "0.5";
       # More Configuration Options
@@ -186,6 +192,7 @@ Then you can enable the program in your `configuration.nix` file:
 }
 
 ```
+
 </details>
 
 <details>
@@ -221,8 +228,14 @@ The home manager config sets up toggling the calculator using `dconf`:
 
 }
 ```
-</details>
 
+> The key for the caclulator toggling script should be associated with XF86Calculator, allowing it to toggle any calculator application, not just the one specified in the configuration. This means that the key binding can be used to manage various calculator applications across different key binding configurations. For e.g.:
+
+```
+"XF86Calculator".action = sh -c "if pidof gnome-calculator > /dev/null; then kill $(pidof gnome-calculator); else gnome-calculator; fi";
+```
+
+</details>
 
 ## Uninstallation
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -92,7 +92,7 @@ in {
     # Load specific kernel modules
     boot.kernelModules = [ "uinput" "i2c-dev" ];
 
-    systemd.services.asus-numberpad-driver = {
+    systemd.user.services.asus-numberpad-driver = {
       description = "Asus Numberpad Driver";
       wantedBy = [ "default.target" ];
       startLimitBurst=20;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -48,7 +48,7 @@ in {
 
     waylandDisplay = lib.mkOption {
       type = lib.types.str;
-      default = "wayland-x";
+      default = "wayland-0";
       description =
         "The WAYLAND_DISPLAY environment variable. Default is a placeholder.";
     };

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -50,7 +50,7 @@ in {
       type = lib.types.str;
       default = "wayland-0";
       description =
-        "The WAYLAND_DISPLAY environment variable. Default is a placeholder.";
+        "The WAYLAND_DISPLAY environment variable. Default is wayland-0.";
     };
 
     ignoreWaylandDisplayEnv = lib.mkOption {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -48,9 +48,16 @@ in {
 
     waylandDisplay = lib.mkOption {
       type = lib.types.str;
-      default = "wayland-0";
+      default = "wayland-x";
       description =
-        "The WAYLAND_DISPLAY environment variable. Default is wayland-0.";
+        "The WAYLAND_DISPLAY environment variable. Default is a placeholder.";
+    };
+
+    ignoreWaylandDisplayEnv = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description =
+        "If true, WAYLAND_DISPLAY will not be set in the service environment.";
     };
 
     runtimeDir = lib.mkOption {
@@ -116,11 +123,10 @@ in {
         Environment = [
           "XDG_SESSION_TYPE=${if cfg.wayland then "wayland" else "x11"}"
           "XDG_RUNTIME_DIR=${cfg.runtimeDir}"
-          # ''WAYLAND_DISPLAY=${cfg.waylandDisplay}''
           "DISPLAY=${cfg.display}"
-        ];
+        ] ++ lib.optional (!cfg.ignoreWaylandDisplayEnv)
+          "WAYLAND_DISPLAY=${cfg.waylandDisplay}";
       };
     };
-
   };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,14 +1,15 @@
-
-inputs: { config, lib, pkgs, ... }:
+inputs:
+{ config, lib, pkgs, ... }:
 
 let
   cfg = config.services.asus-numberpad-driver;
   defaultPackage = inputs.self.packages.${pkgs.system}.default;
 
   # Function to convert configuration options to string
-  toConfigFile = cfg: builtins.concatStringsSep "\n" (
-    [ "[main]" ] ++ lib.attrsets.mapAttrsToList (key: value: "${key} = ${value}") cfg.config
-  );
+  toConfigFile = cfg:
+    builtins.concatStringsSep "\n" ([ "[main]" ]
+      ++ lib.attrsets.mapAttrsToList (key: value: "${key} = ${value}")
+      cfg.config);
 
   # Writable directory for the config file
   configDir = "/etc/asus-numberpad-driver/";
@@ -19,12 +20,13 @@ in {
     layout = lib.mkOption {
       type = lib.types.str;
       default = "up5401ea";
-      description = "The layout identifier for the numberpad driver (e.g. up5401ea). This value is required.";
+      description =
+        "The layout identifier for the numberpad driver (e.g. up5401ea). This value is required.";
     };
 
     config = lib.mkOption {
       type = lib.types.attrsOf lib.types.str;
-      default = {};
+      default = { };
       description = ''
         Configuration options for the numberpad driver.
         These options will be written to a configuration file for the driver.
@@ -40,19 +42,22 @@ in {
     wayland = lib.mkOption {
       type = lib.types.bool;
       default = true;
-      description = "Enable this option to run under Wayland. Disable it for X11.";
+      description =
+        "Enable this option to run under Wayland. Disable it for X11.";
     };
 
     waylandDisplay = lib.mkOption {
       type = lib.types.str;
       default = "wayland-0";
-      description = "The WAYLAND_DISPLAY environment variable. Default is wayland-0.";
+      description =
+        "The WAYLAND_DISPLAY environment variable. Default is wayland-0.";
     };
 
     runtimeDir = lib.mkOption {
       type = lib.types.str;
       default = "/run/user/1000/";
-      description = "The XDG_RUNTIME_DIR environment variable, specifying the runtime directory.";
+      description =
+        "The XDG_RUNTIME_DIR environment variable, specifying the runtime directory.";
     };
   };
 
@@ -66,7 +71,8 @@ in {
     ];
 
     # Write the configuration file to the writable directory
-    environment.etc."asus-numberpad-driver/numberpad_dev".text = toConfigFile cfg;
+    environment.etc."asus-numberpad-driver/numberpad_dev".text =
+      toConfigFile cfg;
 
     # Enable i2c
     hardware.i2c.enable = true;
@@ -95,11 +101,12 @@ in {
     systemd.user.services.asus-numberpad-driver = {
       description = "Asus Numberpad Driver";
       wantedBy = [ "default.target" ];
-      startLimitBurst=20;
-      startLimitIntervalSec=300;
+      startLimitBurst = 20;
+      startLimitIntervalSec = 300;
       serviceConfig = {
         Type = "simple";
-        ExecStart = "${defaultPackage}/share/asus-numberpad-driver/numberpad.py ${cfg.layout} ${configDir}";
+        ExecStart =
+          "${defaultPackage}/share/asus-numberpad-driver/numberpad.py ${cfg.layout} ${configDir}";
         StandardOutput = null;
         StandardError = null;
         Restart = "on-failure";
@@ -107,10 +114,10 @@ in {
         TimeoutSec = 5;
         WorkingDirectory = "${defaultPackage}";
         Environment = [
-          ''XDG_SESSION_TYPE=${if cfg.wayland then "wayland" else "x11"}''
-          ''XDG_RUNTIME_DIR=${cfg.runtimeDir}''
-          ''WAYLAND_DISPLAY=${cfg.waylandDisplay}''
-          ''DISPLAY=${cfg.display}''
+          "XDG_SESSION_TYPE=${if cfg.wayland then "wayland" else "x11"}"
+          "XDG_RUNTIME_DIR=${cfg.runtimeDir}"
+          # ''WAYLAND_DISPLAY=${cfg.waylandDisplay}''
+          "DISPLAY=${cfg.display}"
         ];
       };
     };


### PR DESCRIPTION
1. Runs the service as user, not root.
2. Add an option `ignoreWaylandDisplayEnv = <bool>;` defaulting to `false`. (Not using `WAYLAND_DISPLAY` env var on the systemd service fixed my issue of having to rebuild the config when switching between gnome and niri.)
3. Clarify about added configuration on README and some more improvements.

Didn't completely remove the WAYLAND_DISPLAY option to preserve compatibility and avoid regressions.

Fixes #234 