### PR TITLE
Fix readme NixOS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Then you can enable the program in your `configuration.nix` file:
     wayland = true;
     runtimeDir = "/run/user/1000/";
     waylandDisplay = "wayland-0";
-    ignoreWaylandDisplayEnv = "false";
+    ignoreWaylandDisplayEnv = false;
     config = {
       # e.g. "activation_time" = "0.5";
       # More Configuration Options


### PR DESCRIPTION
ignoreWaylandDisplayEnv value is of type bool