### PR TITLE
fix: eval error on NixOS unstable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     pkgsForEach = nixpkgs.legacyPackages;
   in {
     packages = forAllSystems (system: {
-      default = pkgsForEach.${system}.python311Packages.callPackage ./nix/default.nix {};
+      default = pkgsForEach.${system}.callPackage ./nix/default.nix {};
     });
 
     devShells = forAllSystems (system: {


### PR DESCRIPTION
This is because flakes are unstable feature of NixOS which is constantly changing.
```
 error: do not use python311Packages when building Python packages, specify each used package as a separate argument
```