### PR TITLE
Fix: Asterisk key not working - resolve invalid key codes

### DIFF
--- a/numberpad.py
+++ b/numberpad.py
@@ -208,7 +208,9 @@ def set_defaults_keysym_name_associated_to_evdev_key_reflecting_current_layout()
         mod_name_to_specific_keysym_name('Control'): '',
         'u': '',
         # unicode shortcut - end sequence
-        'space': ''
+        'space': '',
+        # numpad keys
+        'asterisk': ''
     }
 
 
@@ -306,6 +308,10 @@ def load_evdev_keys_for_x11():
     reset_udev_device()
 
   keymap_loaded = True
+  
+  # Manual mapping for asterisk key to fix keysym resolution issue
+  set_evdev_key_for_char('asterisk', EV_KEY.KEY_KPASTERISK)
+  enable_key(EV_KEY.KEY_KPASTERISK)
 
   log.debug("X11 loaded keymap succesfully")
   log.debug(get_keysym_name_associated_to_evdev_key_reflecting_current_layout())
@@ -421,6 +427,10 @@ def wl_load_keymap_state():
         reset_udev_device()
 
     keymap_loaded = True
+    
+    # Manual mapping for asterisk key to fix keysym resolution issue
+    set_evdev_key_for_char('asterisk', EV_KEY.KEY_KPASTERISK)
+    enable_key(EV_KEY.KEY_KPASTERISK)
 
     log.debug("Wayland loaded keymap succesfully")
     log.debug(get_keysym_name_associated_to_evdev_key_reflecting_current_layout())


### PR DESCRIPTION
## Summary

Fixes the asterisk (*) key not working issue where pressing the asterisk key either:
- Results in invalid key codes like `KEY_2F8:760` or `KEY_54:84`
- Causes the NumberPad to turn off immediately
- Produces wrong characters instead of asterisk

## Root Cause

The "asterisk" string in layout files was being resolved through the keysym system, which generated invalid key codes instead of the proper `KEY_KPASTERISK:55`. This caused the driver to fall back to broken unicode input mode.

## Solution

This fix adds proper asterisk key handling by:

1. **Adding 'asterisk' to default keysym mapping dictionary** - ensures it's recognized by the driver
2. **Manual mapping to KEY_KPASTERISK** - directly maps asterisk to the correct keypad asterisk key (`KEY_KPASTERISK:55`)
3. **Universal support** - works for both X11 and Wayland environments
4. **Enables the key** - properly registers `KEY_KPASTERISK` in the virtual input device

## Testing

✅ **Tested on**: Pop\!_OS GNOME (Wayland) with `up5401ea` layout  
✅ **Before fix**: `[KEY_LEFTSHIFT:42, KEY_2F8:760, KEY_8:9]` (broken)  
✅ **After fix**: `KEY_KPASTERISK:55` (working correctly)  
✅ **No regression**: All other numpad keys continue to work normally  

## Log Evidence

**Before (broken):**
```
Aug 15 11:46:51 asus-zenbook /usr/share/asus-numberpad-driver/numberpad.py[12531]: [KEY_LEFTSHIFT:42, KEY_2F8:760, KEY_8:9]
```

**After (working):**
```
Aug 15 13:29:18 asus-zenbook /usr/share/asus-numberpad-driver/numberpad.py[16058]: KEY_KPASTERISK:55
```

## Files Changed

- `numberpad.py`: 11 insertions, 1 deletion
  - Added asterisk to keysym mapping dictionary
  - Added manual KEY_KPASTERISK mapping in X11 keymap loading
  - Added manual KEY_KPASTERISK mapping in Wayland keymap loading

## Closes Issues

Fixes #242 - [Bug]: Asterix key error  
Fixes #210 - [Bug]: Modifier keys not sent properly

## Test Plan

1. Install the driver with the fix
2. Activate NumberPad
3. Press the asterisk (*) key
4. Verify it produces asterisk character instead of invalid key codes
5. Verify NumberPad doesn't turn off unexpectedly
6. Test other numpad keys for regression