### PR TITLE
Fix dependencies + update python library

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,11 +1,11 @@
 { lib
-, python311Packages
+, python313Packages
 , pkgs
 }:
 
 let
   # Define the Python packages required
-  pythonPackages = pkgs.python311.withPackages (ps: with ps; [
+  pythonPackages = pkgs.python313.withPackages (ps: with ps; [
     numpy
     libevdev
     xlib
@@ -15,9 +15,10 @@ let
     pywayland
     xkbcommon
     systemd
+    xcffib
   ]);
 in
-python311Packages.buildPythonPackage {
+python313Packages.buildPythonPackage {
   pname = "asus-numberpad-driver";
   version = "6.5.1";
   src = ../.;
@@ -34,7 +35,7 @@ python311Packages.buildPythonPackage {
     libxkbcommon
     libgcc
     gcc
-    pythonPackages  # Python dependencies already include python311
+    pythonPackages  # Python dependencies already include python313
   ];
 
   doCheck = false;

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -4,12 +4,12 @@
   ...
 }:
 let
-  mainPkg = python311Packages.callPackage ./default.nix {};
+  mainPkg = python313Packages.callPackage ./default.nix {};
 in
 mainPkg.overrideAttrs (oa: {
     nativeBuildInputs =
       [
-        python311Packages.pip
+        python313Packages.pip
       ]
       ++ (oa.nativeBuildInputs or []);
 })


### PR DESCRIPTION
Due to the recent commit of adding "xcffib" as a dependent library, the asus-numberpad-driver service fails to load in NixOS due to the missing dependency.

This PR aims to resolve the dependency issues and update the python packages to 3.13

Laptop Tested: ASUS Zenbook S13 OLED (UM5302TA) with Numpad layout UP5401EA. 

System built: NixOS Unstable 25.11pre846535 (Commit: 200775955deac) on x86-64 Linux.

Consider testing my fork in your NixOS system to ensure I have not missed anything.