### PR TITLE
fix shell.nix 

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,6 +1,5 @@
 {
-  python311Packages,
-  pkgs,
+  python313Packages,
   ...
 }:
 let


### PR DESCRIPTION
Previous fix worked on my case, verifying the files and forgot to change the imports in shell.nix

Reproduced Error:

```
error:
       … while checking flake output 'devShells'
         at /nix/store/fwrmvnm1rgikp9xmyx6kwxq1nwqj4d9z-source/flake.nix:14:5:
           13|
           14|     devShells = forAllSystems (system: {
             |     ^
           15|       default = pkgsForEach.${system}.callPackage ./nix/shell.nix {};

       … while checking the derivation 'devShells.x86_64-linux.default'
         at /nix/store/fwrmvnm1rgikp9xmyx6kwxq1nwqj4d9z-source/flake.nix:15:7:
           14|     devShells = forAllSystems (system: {
           15|       default = pkgsForEach.${system}.callPackage ./nix/shell.nix {};
             |       ^
           16|     });

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: undefined variable 'python313Packages'
       at /nix/store/fwrmvnm1rgikp9xmyx6kwxq1nwqj4d9z-source/nix/shell.nix:6:13:
            5| let
            6|   mainPkg = python313Packages.callPackage ./default.nix {};
             |             ^
            7| in
```

Python import changed from 3.11 to 3.13

Flake check result:

```
evaluating flake...
checking flake output 'packages'...
checking derivation packages.x86_64-linux.default...
derivation evaluated to /nix/store/wn06mfvr9id3vjra7hlpq7iwkmxgw0fy-python3.13-asus-numberpad-driver-6.5.1.drv
checking flake output 'devShells'...
checking derivation devShells.x86_64-linux.default...
derivation evaluated to /nix/store/0mvknlrv3701yvgni5sjnmprsqa8c0bp-python3.13-asus-numberpad-driver-6.5.1.drv
checking flake output 'overlays'...
checking overlay 'overlays.default'...
checking flake output 'nixosModules'...
checking NixOS module 'nixosModules.default'...
warning: The check omitted these incompatible systems: aarch64-linux, i686-linux
Use '--all-systems' to check all.
```