### PR TITLE
Add auto-installation of qdbus in fedora when using KDE Plasma. 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,9 @@ LOGS_INSTALL_LOG_FILE_PATH="$LOGS_DIR_PATH/$LOGS_INSTALL_LOG_FILE_NAME"
         if [ "$XDG_SESSION_TYPE" == "wayland" ]; then
             sudo dnf -y install wayland-devel
         fi
+        if [ "$DESKTOP_SESSION" == "plasma" ]; then
+            sudo dnf -y install qdbus
+        fi
 
     elif [[ $(command -v yum 2>/dev/null) ]]; then
         PACKAGE_MANAGER="yum"


### PR DESCRIPTION
When I installed the driver on Fedora 42 with KDE Plasma 6.4 clicks on the touchpad when the numpad was activated were still being registered. That was because qdbus wasn't installed. The change I'm proposing auto-installs qdbus when on Fedora and KDE Plasma. 