### PR TITLE
Add python-periphery as to nix python dependencies

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -16,6 +16,7 @@ let
     xkbcommon
     systemd
     xcffib
+    python-periphery
   ]);
 in
 python313Packages.buildPythonPackage {


### PR DESCRIPTION
Fixing flake package build by adding missing dependency.