### PR TITLE
Nix: Rename build dependency xorg.xinput to xinput

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -29,7 +29,7 @@ python313Packages.buildPythonPackage {
     ibus
     libevdev
     curl
-    xorg.xinput
+    xinput
     i2c-tools
     libxml2
     libxkbcommon


### PR DESCRIPTION
NixOS recently deprecated the use of xorg package sets and building NixOS with the asus-numberpad-driver yields the following warning:
```bash
evaluation warning: The xorg package set has been deprecated, 'xorg.xinput' has been renamed to 'xinput'
```
This PR updates the dependency of asus-numberpad-driver to use the modern xinput package provided by NixOS.

Laptop Tested: ASUS Zenbook S13 OLED (UM5302TA) with Numpad layout UP5401EA.

NixOS Version: 26.05.20260318.b40629e (Yarara)