### PR TITLE
Add backwards compatibility with old xorg.xinput package name

### DIFF
--- a/nix/compat.nix
+++ b/nix/compat.nix
@@ -1,0 +1,8 @@
+{ pkgs }:
+
+{
+  xinput =
+    if pkgs ? xorg.xinput
+    then pkgs.xorg.xinput
+    else pkgs.xinput;
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,6 +17,9 @@ let
     xcffib
     python-periphery
   ]);
+
+  # Add backwards compatibility on packages name changes
+  compat = import ./compat.nix { inherit pkgs; };
 in
 python313Packages.buildPythonPackage {
   pname = "asus-numberpad-driver";
@@ -29,7 +32,7 @@ python313Packages.buildPythonPackage {
     ibus
     libevdev
     curl
-    xinput
+    compat.xinput
     i2c-tools
     libxml2
     libxkbcommon


### PR DESCRIPTION
Add backwards compatibility with old xorg.xinput package name