### PR TITLE
Add device info for ASUF1415:00 2808:0224 (UX3405CA)

### DIFF
--- a/touchpad_product_id_info.md
+++ b/touchpad_product_id_info.md
@@ -30,6 +30,7 @@
 | ASUE1900:00 04F3:31AF ||     |     |
 | ASUE1A00:00 04F3:31DE ||     |     |
 | ASUE1A01:00 04F3:31D4 ||     |     |
+| ASUF1415:00 2808:0224 || confirmed working (device_addr=0x15) ||ASUS Zenbook 14 UX3405CA|[@karandesai2005](https://github.com/karandesai2005) — [writeup](https://github.com/karandesai2005/asus-numpad-linux)|
 | ELAN1200:00 04F3:301A ||     |     |
 | ELAN1200:00 04F3:3022 ||     |     |
 | ELAN1200:00 04F3:303C ||     |     |


### PR DESCRIPTION
Confirmed working with the existing i2c activation sequence. device_addr = 0x15, consistent with the documented default for non-ASUF1416/1205/1204 devices.

Found by reverse engineering the HID report descriptor and confirming the i2c address since this device wasn't in the compatibility table. Full writeup and standalone implementation: https://github.com/karandesai2005/asus-numpad-linux