### PR TITLE
Fix infinite recursion in NixOS module package override

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -5,7 +5,7 @@ let
   cfg = config.services.asus-numberpad-driver;
   defaultPackage = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
-  package = package.override {
+  package = defaultPackage.override {
     waylandSupport = cfg.wayland;
     x11Support = !cfg.wayland;
   };


### PR DESCRIPTION
## Problem

`nix/module.nix` fails to evaluate with `error: infinite recursion encountered`:

```
at .../nix/module.nix:8:13:
     7|
     8|   package = package.override {
      |             ^
```

The `package` binding is defined in terms of itself (`package = package.override { ... }`) instead of `defaultPackage`, so any evaluation of it recurses forever.

The bug is dormant until something forces the value. On recent nixpkgs (`nixos-unstable` 26.11), evaluating `system.build.toplevel` reaches it via the `warnings` -> `systemd.services.asus-numberpad-driver.serviceConfig` path (`ExecStart` uses `package`), so `nixos-rebuild build` now fails outright.

Introduced in 6e10b93 ("Added x11Support option").

Fixes #304.

## Fix

```diff
-  package = package.override {
+  package = defaultPackage.override {
```

`defaultPackage` already accepts `waylandSupport` / `x11Support` (see `nix/default.nix`), which is clearly the intended base.

## Verification

Building a downstream `nixosConfiguration` toplevel that imports `nixosModules.default` with `services.asus-numberpad-driver.enable = true` (and `wayland = false`, exercising the override):

- previously failed at eval with infinite recursion;
- with this change, eval completes and the system derivation instantiates;
- the module's `ExecStart` resolves to `.../numberpad.py <layout> /etc/asus-numberpad-driver/`;
- the package builds, and the override genuinely takes effect — the X11 vs Wayland builds produce **different** closures (X11 build pulls `python-xlib` / `xcffib`, no `pywayland`).
