### PR TITLE
Fix Wayland startup crash before keyboard state initialization

### DIFF
--- a/numberpad.py
+++ b/numberpad.py
@@ -208,7 +208,7 @@ def mod_name_to_specific_keysym_name(mod_name):
                         return key[3:]
             else:
                 return mod_to_specific_keysym_name[mod_name]
-    elif display_wayland:
+    elif display_wayland and keyboard_state:
 
         keymap = keyboard_state.get_keymap()
         num_mods = keymap.num_mods()


### PR DESCRIPTION
## Problem

On Wayland, v7.2.0 can call `mod_name_to_specific_keysym_name()`
before `keyboard_state` has been initialized.

This causes the driver to exit during startup with:

    AttributeError: 'NoneType' object has no attribute 'get_keymap'

The failure occurs at:

    keymap = keyboard_state.get_keymap()

## Fix

Only use the Wayland keymap path once `keyboard_state` is available:

```diff
-    elif display_wayland:
+    elif display_wayland and keyboard_state:
         keymap = keyboard_state.get_keymap()
```

Before the Wayland keyboard state is initialized, the existing fallback path is used.

### Tested on

- ASUS ZenBook UX362FA_RX362FA
- Touchpad: ELAN1401:00 04F3:30DC
- NumberPad layout: ux433fa
- Nobara 44
- KDE Plasma Wayland

### Verification

- v7.1.0 works correctly
- unmodified v7.2.0 consistently crashes during startup
- v7.2.0 with this change starts successfully
- systemd user service remains active/running
- NumberPad activation, input and backlight work correctly