### PR TITLE
Adding support for touchpad device ASCF1400 (Rog Scar G635)

### DIFF
--- a/numberpad.py
+++ b/numberpad.py
@@ -1286,7 +1286,7 @@ while try_times > 0:
             # https://github.com/asus-linux-drivers/asus-numberpad-driver/issues/198
             # https://github.com/asus-linux-drivers/asus-stylus-driver/issues/17
             # https://github.com/asus-linux-drivers/asus-numberpad-driver/issues/308
-            if (touchpad_detected == 0 and ("Name=\"ASUE" in line or "Name=\"ELAN" in line or "Name=\"ASUP" in line or "Name=\"ASUF" in line or "Name=\"ASCP" in line) and "Touchpad" in line and not "9009" in line and not "9008" in line):
+            if (touchpad_detected == 0 and ("Name=\"ASUE" in line or "Name=\"ELAN" in line or "Name=\"ASUP" in line or "Name=\"ASUF" in line or "Name=\"ASCP" in line or "Name=\"ASCF" in line) and "Touchpad" in line and not "9009" in line and not "9008" in line):
                 touchpad_detected = 1
                 log.info('Detecting touchpad from string: \"%s\"', line.strip())
                 touchpad_name = line.split("\"")[1]
@@ -1313,7 +1313,7 @@ while try_times > 0:
                               touchpad, line.strip())
 
             # Look for the keyboard
-            if keyboard_detected == 0 and ("Name=\"AT Translated Set 2 keyboard" in line or (("Name=\"ASUE" in line or "Name=\"Asus" in line or "Name=\"ASUP" in line or "Name=\"ASUF" in line or "Name=\"ASCP" in line) and "Keyboard" in line)):
+            if keyboard_detected == 0 and ("Name=\"AT Translated Set 2 keyboard" in line or (("Name=\"ASUE" in line or "Name=\"Asus" in line or "Name=\"ASUP" in line or "Name=\"ASUF" in line or "Name=\"ASCP" in line or "Name=\"ASCF" in line) and "Keyboard" in line)):
                 keyboard_detected = 1
                 log.info(
                     'Detecting keyboard from string: \"%s\"', line.strip())


### PR DESCRIPTION
On ROG SCAR 16 (2025) (G635LX-RW158WS) :
$ libinput list-devices | grep -Ei 'Device:.*(touchpad|keyboard)'
Device:                  ASCF1400:00 2808:0242 Touchpad
Device:                  ASCF1400:00 2808:0242 Keyboard