### PR TITLE
Fix Fedora KDE QDBus detection with qdbus-qt6

### DIFF
--- a/numberpad.py
+++ b/numberpad.py
@@ -58,7 +58,7 @@ except ImportError:
 GLIB_AVAILABLE = False
 DBUS_AND_GLIB_AVAILABLE = False
 
-QDBUS = shutil.which("qdbus") or shutil.which("qdbus6")
+QDBUS = shutil.which("qdbus") or shutil.which("qdbus6") or shutil.which("qdbus-qt6")
 
 try:
     import gi


### PR DESCRIPTION
Fedora KDE exposes the Qt 6 QDBus CLI in `$PATH` as `qdbus-qt6`.

The current runtime lookup in `numberpad.py` checks only:

```python
shutil.which("qdbus") or shutil.which("qdbus6")
```

On the tested Fedora 44 KDE system, both returned `None`, while `/usr/bin/qdbus-qt6` was available from `qt6-qttools`.

This PR adds `qdbus-qt6` as a third fallback without changing the existing lookup priority.

## Why this matters

With `enabled_touchpad_pointer = 3`, the driver is intended to keep pointer movement available while disabling KDE tap-to-click when the NumberPad is active.

On the tested system, QDBus was not detected, so KWin remained at:

```text
tapToClick = true
tapAndDrag = true
```

while the NumberPad was active.

Rapid NumberPad input could then be interpreted simultaneously as NumberPad keys and touchpad taps, causing text selection followed by replacement of the selected text.

## Hardware-tested result

Tested on real hardware:

- ASUS ExpertBook B9400CBA/B9450CBA
- ELAN `04F3:322D`
- layout `b7402`
- Fedora Linux 44 KDE
- KDE Plasma `6.7.4`
- Wayland / KWin
- kernel `7.1.9-200.fc44.x86_64`
- upstream driver `v7.2.2` during the original diagnosis

Before the fix:

```text
qdbus:  not found
qdbus6: not found
qdbus-qt6: /usr/bin/qdbus-qt6
```

After adding the fallback, the driver could use Fedora's QDBus executable and the tested behavior became:

```text
NumberPad OFF -> tapToClick = true
NumberPad ON  -> tapToClick = false
NumberPad OFF -> tapToClick = true
```

Fast NumberPad input remained stable, the text-selection/deletion problem disappeared, and pointer movement stayed available.

## Scope

The change is intentionally minimal:

```diff
-QDBUS = shutil.which("qdbus") or shutil.which("qdbus6")
+QDBUS = shutil.which("qdbus") or shutil.which("qdbus6") or shutil.which("qdbus-qt6")
```

Systems already providing `qdbus` or `qdbus6` keep the same behavior and lookup priority.

## Additional Fedora/KDE installer observation

During the same investigation, the Fedora KDE session exposed:

```text
DESKTOP_SESSION=/usr/share/wayland-sessions/plasma.desktop
```

while the installer currently uses checks of the form:

```bash
[[ "$DESKTOP_SESSION" == plasma* ]]
```

for Plasma-specific QDBus package installation and warnings.

That is documented in the test report below, but is intentionally **not changed in this PR** to keep this contribution focused on the hardware-tested runtime fix.

## Reproducible investigation and test report

Full hardware-tested report:

https://github.com/pesoiq/asus-expertbook-b9400cba-numberpad-linux

Technical diagnosis:

https://github.com/pesoiq/asus-expertbook-b9400cba-numberpad-linux/blob/main/docs/DIAGNOSIS.md

Final Linux behavior and Windows comparison:

https://github.com/pesoiq/asus-expertbook-b9400cba-numberpad-linux/blob/main/docs/FINAL_BEHAVIOR.md

## AI-assisted investigation disclosure

The diagnostic strategy, test design, log analysis, root-cause isolation, and documentation were developed interactively with **OpenAI ChatGPT (GPT-5.6 Sol)**.

All hardware-dependent tests and final behavior were executed and validated by the repository owner on the real ASUS laptop described above.
